### PR TITLE
Expand disk-space auto cleanup with safe generic commands

### DIFF
--- a/alerts/src/services/DiskSpaceAlert.ts
+++ b/alerts/src/services/DiskSpaceAlert.ts
@@ -122,16 +122,40 @@ export class DiskSpaceAlert {
     }
 
     private deleteLogFiles(): void {
-        try {
-            // Execute cleanup commands while waiting for results
-            execSync("journalctl --vacuum-size=500M");
-            execSync("rm -rf /var/log/*.gz");
-            execSync("npm cache clean --force");
-            execSync("truncate -s 500M /var/log/syslog.1");
-            console.log("DiskSpaceAlert::deleteLogFiles::Old syslog files deleted.");
-        } catch (error) {
-            console.error("DiskSpaceAlert::deleteLogFiles::Failed to delete log files:", error);
+        // Generic, safe cleanup. Each command targets reclaimable caches,
+        // rotated/compressed logs or runtime temp files only, so nothing an
+        // application needs at runtime is removed. Commands run independently
+        // so a failure or a path missing on a given server never blocks the rest.
+        const cleanupCommands: string[] = [
+            // Trim the systemd journal to a small retained window.
+            "journalctl --vacuum-size=200M || true",
+            "journalctl --vacuum-time=3d || true",
+            // Remove rotated / compressed logs (foo.gz, foo.1, foo.old, foo.log.2 ...).
+            "find /var/log -type f -regextype posix-extended -regex '.*\\.(gz|old|xz|[0-9]+)$' -delete || true",
+            // Empty the current syslog.1 in place instead of padding it to a fixed size.
+            "truncate -s 0 /var/log/syslog.1 2>/dev/null || true",
+            // Truncate running Docker container logs without stopping the containers.
+            "truncate -s 0 /var/lib/docker/containers/*/*-json.log 2>/dev/null || true",
+            // Drop dangling Docker images and build cache (never tagged or in use).
+            "command -v docker >/dev/null 2>&1 && docker image prune -f || true",
+            "command -v docker >/dev/null 2>&1 && docker builder prune -f || true",
+            // Package-manager caches, re-downloaded on demand.
+            "apt-get clean || true",
+            "npm cache clean --force || true",
+            // Stale Chromium / Puppeteer temp profiles and old temp files.
+            "rm -rf /tmp/puppeteer_dev_* /tmp/.org.chromium.Chromium.* /tmp/.com.google.Chrome.* 2>/dev/null || true",
+            "find /tmp -mindepth 1 -type f -atime +3 -delete 2>/dev/null || true",
+        ];
+
+        for (const command of cleanupCommands) {
+            try {
+                execSync(command, { stdio: "pipe" });
+            } catch (error) {
+                console.error(`DiskSpaceAlert::deleteLogFiles::Command failed: ${command}`, error);
+            }
         }
+
+        console.log("DiskSpaceAlert::deleteLogFiles::Cleanup commands executed.");
     }
 
     private async checkDiskSpaceAfterCleanup(): Promise<void> {

--- a/alerts/src/services/DiskSpaceAlert.ts
+++ b/alerts/src/services/DiskSpaceAlert.ts
@@ -121,30 +121,47 @@ export class DiskSpaceAlert {
             .join(" ");
     }
 
+    // Always keep at least this many minutes of logs after any cleanup.
+    private readonly retainMinutes = 360; // 6 hours
+
     private deleteLogFiles(): void {
-        // Generic, safe cleanup. Each command targets reclaimable caches,
-        // rotated/compressed logs or runtime temp files only, so nothing an
-        // application needs at runtime is removed. Commands run independently
-        // so a failure or a path missing on a given server never blocks the rest.
+        // Generic, safe cleanup. Every command only removes reclaimable caches,
+        // already-rotated logs, log lines older than the last 6 hours, or temp
+        // files that are idle. Nothing an app needs at runtime is touched, and
+        // the last 6 hours of logs always survive. Commands run independently so
+        // a failure or a path missing on a given server never blocks the rest.
+        const minutes = this.retainMinutes;
+
+        // Keep only the last 6 hours of each large running container log, in place,
+        // so the container keeps writing and recent logs survive. Streams with awk
+        // (index/substr only, so it works under both mawk and gawk) to stay memory
+        // safe on very large logs.
+        const trimContainerLogs =
+            "cutoff=$(date -u -d '6 hours ago' +%Y-%m-%dT%H:%M:%S 2>/dev/null); [ -n \"$cutoff\" ] || exit 0; " +
+            "for f in $(find /var/lib/docker/containers -name '*-json.log' -size +20M 2>/dev/null); do " +
+            "t=\"$f.cleanup.tmp\"; " +
+            "awk -v c=\"$cutoff\" 'BEGIN{p=\"\\\"time\\\":\\\"\"} {i=index($0,p); if(i){v=substr($0,i+8,19); if(v>=c) print}}' \"$f\" > \"$t\" 2>/dev/null " +
+            "&& cat \"$t\" > \"$f\" 2>/dev/null; rm -f \"$t\"; done";
+
         const cleanupCommands: string[] = [
-            // Trim the systemd journal to a small retained window.
-            "journalctl --vacuum-size=200M || true",
-            "journalctl --vacuum-time=3d || true",
-            // Remove rotated / compressed logs (foo.gz, foo.1, foo.old, foo.log.2 ...).
-            "find /var/log -type f -regextype posix-extended -regex '.*\\.(gz|old|xz|[0-9]+)$' -delete || true",
-            // Empty the current syslog.1 in place instead of padding it to a fixed size.
-            "truncate -s 0 /var/log/syslog.1 2>/dev/null || true",
-            // Truncate running Docker container logs without stopping the containers.
-            "truncate -s 0 /var/lib/docker/containers/*/*-json.log 2>/dev/null || true",
+            // Trim the systemd journal to the last 2 days (well above the 6h floor).
+            "journalctl --vacuum-time=2d || true",
+            // Remove already-rotated / compressed logs untouched for over 6h
+            // (foo.gz, foo.1, foo.old, foo.log.2 ...); recently rotated logs are kept.
+            `find /var/log -type f -regextype posix-extended -regex '.*\\.(gz|old|xz|[0-9]+)$' -mmin +${minutes} -delete || true`,
+            // Keep only the last 6h of each large running Docker container log.
+            `${trimContainerLogs} || true`,
             // Drop dangling Docker images and build cache (never tagged or in use).
             "command -v docker >/dev/null 2>&1 && docker image prune -f || true",
             "command -v docker >/dev/null 2>&1 && docker builder prune -f || true",
             // Package-manager caches, re-downloaded on demand.
             "apt-get clean || true",
             "npm cache clean --force || true",
-            // Stale Chromium / Puppeteer temp profiles and old temp files.
-            "rm -rf /tmp/puppeteer_dev_* /tmp/.org.chromium.Chromium.* /tmp/.com.google.Chrome.* 2>/dev/null || true",
-            "find /tmp -mindepth 1 -type f -atime +3 -delete 2>/dev/null || true",
+            // Stale Chromium / Puppeteer temp profiles idle for over 6h, so an
+            // in-flight render is never removed.
+            `find /tmp -maxdepth 1 \\( -name 'puppeteer_dev_*' -o -name '.org.chromium.Chromium.*' -o -name '.com.google.Chrome.*' \\) -mmin +${minutes} -exec rm -rf {} + 2>/dev/null || true`,
+            // Other temp files not modified in over 3 days.
+            "find /tmp -mindepth 1 -type f -mtime +3 -delete 2>/dev/null || true",
         ];
 
         for (const command of cleanupCommands) {


### PR DESCRIPTION
## What

Expands the automated disk-space cleanup in `alerts/DiskSpaceAlert.deleteLogFiles()` with safe, generic reclaim commands, fixes a bug that was inflating syslog, and guarantees the last 6 hours of logs and every running app survive cleanup.

## Why

`truncate -s 500M /var/log/syslog.1` sets the file to exactly 500M, so on servers where the rotated syslog was smaller it padded the file with null bytes up to 500M. This is the source of the oversized, junk-filled `syslog.1` seen during cleanup on DL_API_S2. The single try/catch also meant the first failing command aborted every cleanup after it.

## Changes

- Run each cleanup command independently so a failure or a path missing on a given server never blocks the rest.
- Every log-removing step keeps at least the last 6 hours:
  - journal vacuum is time based (`--vacuum-time=2d`) so a size cap can never cut into recent entries
  - rotated and compressed log removal is guarded with `-mmin +360`, so a freshly rotated log is never deleted
  - running Docker container logs are trimmed to the last 6 hours in place with a streaming, mawk and gawk compatible filter instead of a blanket `truncate -s 0`, so live apps keep recent logs and keep running
  - Chromium and Puppeteer temp profiles are removed only when idle for over 6 hours, so an in-flight render is never deleted
  - other temp files use `mtime` instead of `atime` to stay safe on `noatime` mounts
- Reclaimable-only cleanups that never affect a running app: dangling Docker image and build cache prune, `apt-get clean`, `npm cache clean --force`.

Docker and other host-specific commands are guarded so they no-op cleanly where they do not apply.

## Testing

Verified on a live server (API 2):

- `npm run build` passes; every shell command was checked for portability (`awk` uses `index`/`substr` only, GNU `date`/`find`/`journalctl` confirmed).
- The compiled Docker-trim command was extracted from `dist` and run end to end against a synthetic json log: old lines dropped, last-6h lines kept, container inode preserved.
- Dry-run of the rotated-log find: matches only old rotated and `.gz` files, active `syslog`/`auth.log` excluded.
- Dry-run of the temp-profile find: 12,953 profiles idle over 6h would be cleared, 240 active profiles (under 6h) preserved.
